### PR TITLE
feat(p2p): update status/metadata to better track eth2/devp2p

### DIFF
--- a/p2p-specs/p2p-interface.md
+++ b/p2p-specs/p2p-interface.md
@@ -98,10 +98,11 @@ This section outlines constants that are used in this spec.
 
 | Name | Value | Description |
 |---|---|---|
-| `GOSSIP_MAX_SIZE`    | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages. |
-| `MAX_OPS_PER_REQUEST`| `4096` | Maximum number of UserOps in a single request. |
-| `RESP_TIMEOUT`	     | `10s` | The maximum time for complete response transfer. |
-| `TTFB_TIMEOUT`       | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
+| `GOSSIP_MAX_SIZE`       | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages. |
+| `MAX_OPS_PER_REQUEST`   | `4096` | Maximum number of UserOps in a single request. |
+| `RESP_TIMEOUT`	        | `10s` | The maximum time for complete response transfer. |
+| `TTFB_TIMEOUT`          | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
+| `MAX_SUPPORTED_MEMPOOLS`| 1024 | The maximum amount of supported mempools. |
 
 
 ## MetaData
@@ -112,13 +113,15 @@ Bundlers MUST locally store the following `MetaData`:
 (
   seq_number: uint64
   mempool_nets: Bitvector[MEMPOOL_SUBNET_COUNT]
+  supported_mempools: List[Bytes32, MAX_SUPPORTED_MEMPOOLS]
 )
 ```
 
 Where
 
-`seq_number` is a `uint64` starting at 0 used to version the node's metadata. If any other field in the local `MetaData` changes, the node MUST increment `seq_number` by 1.
-`mempool_nets` is a Bitvector representing the node's persistent mempool subnet subscriptions.
+- `seq_number` is a `uint64` starting at 0 used to version the node's metadata. If any other field in the local `MetaData` changes, the node MUST increment `seq_number` by 1.
+- `mempool_nets` is a Bitvector representing the node's persistent mempool subnet subscriptions.
+- `supported_mempools` is a list of [`mempool-id`](#Mempool-id)s
 
 
 ## The gossip domain: gossipsub
@@ -390,12 +393,16 @@ All messages that contain only a single field MUST be encoded directly as the ty
 Request, Response Content:
 ```
 (
-  List[bytes32,MAX_OPS_PER_REQUEST]
+  chain_id: uint64
+  block_hash: Bytes32
+  block_number: uint64
 )
 ```
 The fields are, as seen by the client at the time of sending the message:
 
-- supported_mempools - List of supported mempools.
+- chain_id - Chain ID of the bundler's network. For a community curated list of chain IDs, see https://chainid.network.
+- block_hash - Last block hash seen by the bundler.
+- block_number - Las block number seen by the bundler.
 
 The dialing client MUST send a `Status` request upon connection.
 
@@ -405,7 +412,8 @@ The response MUST consist of a single `response_chunk`.
 
 Clients SHOULD immediately disconnect from one another following the handshake above under the following conditions:
 
-1. If the `supported_mempools` and client's own list of supported mempools are disjoint.
+1. If `chain_id` does not match the node's local `chain_id`, since the peer is on another network.
+2. Clients MAY choose to disconnect from peers whose `block_number` is sufficiently behind their local block number. Implementers are free to implement such behavior in their own way. Note that some amount of leniency is suggested as nodes discover new blocks at different rates.
 
 #### Goodbye
 


### PR DESCRIPTION
Add the suggestion from: https://hackmd.io/@dancoombs/r1u4CcB-p#statusmetadata

1. Move `supported_mempools` list to metadata
2. Change the `Status` request/response to contain status data. This is based off of:

- devp2p: https://github.com/ethereum/devp2p/blob/master/caps/eth.md#status-0x00
  -  `networkid` -> `chain_id`
  - `td` ~ `block_number`
  - `blockhash` -> `block_hash`
- eth2: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#status
  -  `fork_digest` ~ `chain_id`
  - The rest are similar to block number/block hash.